### PR TITLE
SC-3240

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,7 +7,9 @@ plugins {
 }
 
 // We keep this here so it can be exposed to BuildConfig.
-val nabtoWrapperVersion = "webrtc-SNAPSHOT"
+val nabtoWrapperVersion = "3.0.1"
+val webrtcVersion = "main-SNAPSHOT"
+
 
 android {
     compileSdk = 33
@@ -74,7 +76,7 @@ dependencies {
     implementation ("com.nabto.edge.client:library-ktx:$nabtoWrapperVersion")
     implementation ("com.nabto.edge.client:iam-util:$nabtoWrapperVersion")
     implementation ("com.nabto.edge.client:iam-util-ktx:$nabtoWrapperVersion")
-    implementation ("com.nabto.edge.client:webrtc:$nabtoWrapperVersion")
+    implementation ("com.nabto.edge.client:webrtc:$webrtcVersion")
 
     // Kotlin dependencies
     implementation ("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,12 +12,12 @@ val webrtcVersion = "main-SNAPSHOT"
 
 
 android {
-    compileSdk = 33
+    compileSdk = 34
     namespace = "com.nabto.edge.webrtcdemo"
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         buildConfigField("String", "NABTO_WRAPPER_VERSION", "\"${nabtoWrapperVersion}\"")
 
@@ -58,18 +58,18 @@ android {
 
 dependencies {
     // Android dependencies
-    implementation ("androidx.core:core-ktx:1.9.0")
-    implementation ("androidx.appcompat:appcompat:1.5.1")
-    implementation ("com.google.android.material:material:1.7.0")
+    implementation ("androidx.core:core-ktx:1.13.1")
+    implementation ("androidx.appcompat:appcompat:1.7.0")
+    implementation ("com.google.android.material:material:1.12.0")
     implementation ("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation ("androidx.navigation:navigation-fragment-ktx:2.5.3")
-    implementation ("androidx.navigation:navigation-ui-ktx:2.5.3")
-    implementation ("androidx.navigation:navigation-dynamic-features-fragment:2.5.3")
+    implementation ("androidx.navigation:navigation-fragment-ktx:2.7.7")
+    implementation ("androidx.navigation:navigation-ui-ktx:2.7.7")
+    implementation ("androidx.navigation:navigation-dynamic-features-fragment:2.7.7")
     implementation ("androidx.legacy:legacy-support-v4:1.0.0")
-    implementation ("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
-    implementation ("androidx.lifecycle:lifecycle-livedata-ktx:2.5.1")
+    implementation ("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
+    implementation ("androidx.lifecycle:lifecycle-livedata-ktx:2.8.4")
     implementation ("com.google.android.gms:play-services-vision:20.1.3")
-    implementation ("androidx.preference:preference-ktx:1.2.0")
+    implementation ("androidx.preference:preference-ktx:1.2.1")
 
     // Nabto dependencies
     implementation ("com.nabto.edge.client:library:$nabtoWrapperVersion")
@@ -82,13 +82,13 @@ dependencies {
     implementation ("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
     implementation ("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.6.2")
     implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
-    implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
-    implementation ("androidx.annotation:annotation:1.4.0")
-    implementation ("androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1")
-    implementation ("androidx.lifecycle:lifecycle-process:2.5.1")
+    implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    implementation ("androidx.annotation:annotation:1.8.2")
+    implementation ("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.4")
+    implementation ("androidx.lifecycle:lifecycle-process:2.8.4")
 
     // Room persistence library to use a database abstracted over sqlite
-    val roomVersion = "2.4.2"
+    val roomVersion = "2.6.1"
     implementation ("androidx.room:room-runtime:$roomVersion")
     kapt ("androidx.room:room-compiler:$roomVersion")
     implementation ("androidx.room:room-ktx:$roomVersion")
@@ -117,6 +117,6 @@ dependencies {
     implementation ("io.getstream:stream-webrtc-android-ktx:$webrtcVersion")
 
     testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.3")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,10 +18,10 @@ android {
     defaultConfig {
         minSdk = 26
         targetSdk = 34
-        versionCode = 1
+        versionCode = 2
         buildConfigField("String", "NABTO_WRAPPER_VERSION", "\"${nabtoWrapperVersion}\"")
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runneqr.AndroidJUnitRunner"
         // consumerProguardFiles("consumer-rules.pro")
     }
 
@@ -57,9 +57,14 @@ android {
 }
 
 dependencies {
+    // Google play libraries
+    implementation ("com.google.android.play:asset-delivery:2.2.2")
+    implementation ("com.google.android.play:app-update:2.1.0")
+    implementation ("com.google.android.gms:play-services-tasks:18.2.0")
+    implementation ("com.google.android.play:feature-delivery:2.1.0")
+
     // Android dependencies
     implementation ("androidx.core:core-ktx:1.13.1")
-    implementation ("androidx.appcompat:appcompat:1.7.0")
     implementation ("com.google.android.material:material:1.12.0")
     implementation ("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation ("androidx.navigation:navigation-fragment-ktx:2.7.7")
@@ -83,7 +88,6 @@ dependencies {
     implementation ("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.6.2")
     implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
-    implementation ("androidx.annotation:annotation:1.8.2")
     implementation ("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.4")
     implementation ("androidx.lifecycle:lifecycle-process:2.8.4")
 
@@ -102,7 +106,7 @@ dependencies {
     testImplementation ("io.insert-koin:koin-test:$koinVersion")
 
     // Amplify for Cognito integration
-    val amplifyVersion = "2.13.2"
+    val amplifyVersion = "2.21.0"
     implementation ("com.amplifyframework:core-kotlin:$amplifyVersion")
     implementation ("com.amplifyframework:aws-auth-cognito:$amplifyVersion")
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
         versionCode = 2
         buildConfigField("String", "NABTO_WRAPPER_VERSION", "\"${nabtoWrapperVersion}\"")
 
-        testInstrumentationRunner = "androidx.test.runneqr.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // consumerProguardFiles("consumer-rules.pro")
     }
 

--- a/app/src/main/java/com/nabto/edge/webrtcdemo/util.kt
+++ b/app/src/main/java/com/nabto/edge/webrtcdemo/util.kt
@@ -72,20 +72,6 @@ fun Fragment.clearFocusAndHideKeyboard() {
     }
 }
 
-/**
- * This function is meant to achieve the same as calling navigate with inclusive popUpTo
- * Using navigate in that way seems to be currently bugged, so we have our own
- * slightly hacky alternative here.
- */
-fun NavController.navigateAndPopUpToRoute(route: String, inclusive: Boolean = false) {
-    Log.i("NavController", backQueue.map{ it.destination.route }.joinToString())
-    val entry = backQueue.last { it.destination.route == route }
-    val id = entry.destination.id
-    navigate(route, navOptions {
-        popUpTo(id) { this.inclusive = inclusive }
-    })
-}
-
 fun NavController.navigateAndClearBackStack(route: String) {
     navigate(
         route,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.3.0" apply false
-    id("com.android.library") version "8.3.0" apply false
+    id("com.android.application") version "8.3.2" apply false
+    id("com.android.library") version "8.3.2" apply false
     id("org.jetbrains.kotlin.android") version "1.6.21" apply false
     kotlin("jvm") version "1.7.0"
     kotlin("plugin.serialization") version "1.9.0"


### PR DESCRIPTION
* Updates AGP from 8.3.0 to 8.3.2
* Nabto libraries now use version 3.0.1
* Nabto WebRTC library now uses version main-SNAPSHOT
* Fixed feature-delivery transitive dependency was being blocked by Google Play
* Several other libraries have been updated to their latest versions